### PR TITLE
[Refactor] Topic API 수정

### DIFF
--- a/src/main/kotlin/kr/ac/kookmin/wuung/batch/TopicBatch.kt
+++ b/src/main/kotlin/kr/ac/kookmin/wuung/batch/TopicBatch.kt
@@ -69,7 +69,7 @@ class TopicBatch(
         return ItemProcessor { record ->
             val prompt = recordPrompt.trimIndent()
 
-            if(record.status == TopicFeedbackStatus.PROCESSING || record.status == TopicFeedbackStatus.COMPLETED)
+            if(record.status == TopicFeedbackStatus.PROCESSING || record.status == TopicFeedbackStatus.COMPLETED || record.status == TopicFeedbackStatus.NOFEEDBACK)
                 return@ItemProcessor record
 
             record.status = TopicFeedbackStatus.PROCESSING

--- a/src/main/kotlin/kr/ac/kookmin/wuung/controller/TopicController.kt
+++ b/src/main/kotlin/kr/ac/kookmin/wuung/controller/TopicController.kt
@@ -373,6 +373,13 @@ class TopicController(
                 )]
             ),
             ApiResponse(
+                responseCode = "403", description = "Limit Reached, Feedback can't add",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ApiResponseDTO::class)
+                )]
+            ),
+            ApiResponse(
                 responseCode = "404", description = "Feedback topic not found",
                 content = [Content(
                     mediaType = "application/json",
@@ -419,6 +426,9 @@ class TopicController(
         if(topic.user?.id != userDetails.id) throw UnauthorizedException()
 
         val feedbackNum = topic.topicFeedback.size
+
+        if (feedbackNum >= 7) throw LimitReachedException()
+
 
         // Limit Reached 예외 대신 데이터베이스에 데이터 추가 후 ID 반환
          if(feedbackNum >= 5) {

--- a/src/main/kotlin/kr/ac/kookmin/wuung/exceptions/exceptions.kt
+++ b/src/main/kotlin/kr/ac/kookmin/wuung/exceptions/exceptions.kt
@@ -17,4 +17,5 @@ class AiFeedbackErrorException : CustomException("AI Feedback error raised", 500
 class RecordAlreadyCreatedException : CustomException("Record already created", 409)
 
 class LimitReachedException : CustomException("Limit reached", 403)
+class AiFeedbackNotEnableException : CustomException("No feedback record, can\'t update", 403)
 class InvalidIssuerException : CustomException("Invalid Issuer", 403)

--- a/src/main/kotlin/kr/ac/kookmin/wuung/model/TopicFeedback.kt
+++ b/src/main/kotlin/kr/ac/kookmin/wuung/model/TopicFeedback.kt
@@ -14,6 +14,7 @@ enum class TopicFeedbackStatus(val value: Short) {
     QUEUED(0),
     PROCESSING(1),
     COMPLETED(2),
+    NOFEEDBACK(3),
     PROCESSING_ERROR(10)
 }
 


### PR DESCRIPTION
사용자의 마지막 메시지를 받기 위해 NOFEEDBACK enum 추가 및
NOFEEDBACK인 topicFeedbackAI 피드백을 받지 않도록 조치

## ✨ 변경 내용 (What’s changed?)

NOFEEDBACK인 내용은 AI 피드백을 받지 않도록 조치

## 📂 관련 이슈 (Related issues)
- open #115 

## ✅ 체크리스트 (Checklist)

- [✅] 코드가 정상적으로 동작하며 빌드에 통과합니다.
- [✅] 테스트를 추가했거나, 기존 테스트가 충분합니다.
- [✅] 코드 스타일 가이드를 따랐습니다.
- [✅] PR 내용에 맞는 커밋 메시지를 작성했습니다.
- [✅] 셀프 리뷰를 완료했습니다.

## 💬 추가 설명 (Additional context)
사용자가 제한에 걸린 이후 추가적인 메시지를 저장할 수 있도록 코드를 리팩토링
