### PR TITLE
[hotfix] DiagnosisScale.description changed "varchar(128)" to "TEXT"

### DIFF
--- a/src/main/kotlin/kr/ac/kookmin/wuung/model/DiagnosisScales.kt
+++ b/src/main/kotlin/kr/ac/kookmin/wuung/model/DiagnosisScales.kt
@@ -20,6 +20,6 @@ data class DiagnosisScale(
     @Column(nullable = false, length = 32)
     var scaleName: String? = null,
 
-    @Column(nullable = false, length = 128)
+    @Column(nullable = false, columnDefinition = "TEXT")
     var description: String? = null
 )


### PR DESCRIPTION
## ✨ 변경 내용 (What’s changed?)

<!-- 주요 변경 사항을 간단히 설명해주세요. -->
- DiagnosisScale.description column changed to TEXT

## 📂 관련 이슈 (Related issues)

<!-- 이 PR과 관련된 이슈 번호를 적어주세요. -->
- None.

## 📸 스크린샷 (UI 변경이 있을 경우)

| Before | After |
|--------|-------|
| 이미지 | 이미지 |

<!-- 없으면 생략 가능 -->

## ✅ 체크리스트 (Checklist)

- [x] 코드가 정상적으로 동작하며 빌드에 통과합니다.
- [x] 테스트를 추가했거나, 기존 테스트가 충분합니다.
- [x] 코드 스타일 가이드를 따랐습니다.
- [x] PR 내용에 맞는 커밋 메시지를 작성했습니다.
- [x] 셀프 리뷰를 완료했습니다.

## 💬 추가 설명 (Additional context)

<!-- 리뷰어가 알아두면 좋을 보충 설명이 있다면 적어주세요. -->
- DiagnosisScale 테이블의 description이 당초 "VARCHAR(128)" 로 선언되어 있었으나, 자세한 설명을 적기에는 모자란 상황이다.
- 따라서 "TEXT"로 columnType을 변경하였음.
